### PR TITLE
Add alc.detect-ns to external resources

### DIFF
--- a/doc/external-resources.md
+++ b/doc/external-resources.md
@@ -3,6 +3,7 @@
 ## Projects
 
 - [adorn](https://github.com/sogaiu/adorn). An exploration of editor micro helpers.
+- [alc.detect-ns](https://github.com/sogaiu/alc.detect-ns). Detect namespace of Clojure source code.
 - [alc.enum-repls](https://github.com/sogaiu/alc.enum-repls). Find information about local networked Clojure REPLs, notably port numbers.
 - [alc.x-as-tests](https://github.com/sogaiu/alc.x-as-tests). Use a variety of things (e.g. comment block content) as tests.
 - [babashka](https://github.com/borkdude/babashka). A Clojure babushka for the grey areas of Bash.


### PR DESCRIPTION
This is a request to add a tool to the external resources page.

The utility is for detecting a namespace of Clojure source.  It can be used by editors or other programs wishing to gather information.

I am currently using it in an editor to support working with a REPL with some success.

Thanks for the consideration.